### PR TITLE
Refine jj stack handling and branch synchronization

### DIFF
--- a/src/almighty.rs
+++ b/src/almighty.rs
@@ -1,5 +1,5 @@
 use crate::command::CommandExecutor;
-use crate::constants::DEFAULT_BASE_BRANCH;
+use crate::constants::{CHANGES_BRANCH_PREFIX, DEFAULT_BASE_BRANCH, PUSH_BRANCH_PREFIX};
 use crate::github::GitHubClient;
 use crate::jj::JujutsuClient;
 use crate::state::StateManager;
@@ -46,6 +46,8 @@ impl AlmightyPush {
 
         // Categorize revisions
         let (to_create, to_update) = self.categorize_revisions(revisions, &existing_branches)?;
+        let created_count = to_create.len();
+        let updated_count = to_update.len();
 
         // Check for PRs to reopen
         let mut updated_to_update = to_update;
@@ -59,15 +61,24 @@ impl AlmightyPush {
         // Push branches
         self.jj.push_revisions(&mut all_revisions)?;
 
-        // Copy updated branch names back to original revisions
-        for (i, rev) in all_revisions.iter().enumerate() {
-            if let Some(branch_name) = &rev.branch_name {
-                revisions[i].branch_name = Some(branch_name.clone());
+        // Copy updated branch names back to original revisions using change-id lookup
+        let branch_map: HashMap<_, _> = all_revisions
+            .iter()
+            .filter_map(|rev| {
+                rev.branch_name
+                    .as_ref()
+                    .map(|branch| (rev.change_id.clone(), branch.clone()))
+            })
+            .collect();
+
+        for rev in revisions.iter_mut() {
+            if let Some(branch_name) = branch_map.get(&rev.change_id) {
+                rev.branch_name = Some(branch_name.clone());
             }
         }
 
         // Print summary
-        self.print_push_summary(&all_revisions)?;
+        self.print_push_summary(created_count, updated_count)?;
 
         Ok(existing_branches)
     }
@@ -106,15 +117,10 @@ impl AlmightyPush {
         revision: &Revision,
         existing_branches: &HashMap<String, String>,
     ) -> Option<String> {
-        for branch_name in existing_branches.keys() {
-            for n in &[8, 12] {
-                let len = revision.change_id.len().min(*n);
-                if branch_name.contains(&revision.change_id[..len]) {
-                    return Some(branch_name.clone());
-                }
-            }
-        }
-        None
+        existing_branches
+            .keys()
+            .find(|branch_name| Self::branch_matches_change(branch_name, &revision.change_id))
+            .cloned()
     }
 
     /// Check if any PRs need to be reopened
@@ -130,19 +136,16 @@ impl AlmightyPush {
 
         for rev in revisions {
             for branch_name in existing_branches.keys() {
-                for n in &[8, 12] {
-                    let len = rev.change_id.len().min(*n);
-                    if branch_name.contains(&rev.change_id[..len]) {
-                        if self.github.reopen_pr_if_needed(branch_name)? {
-                            // Add to update list if not already there
-                            if !to_update.iter().any(|r| r.change_id == rev.change_id) {
-                                let mut updated_rev = rev.clone();
-                                updated_rev.branch_name = Some(branch_name.clone());
-                                to_update.push(updated_rev);
-                            }
+                if Self::branch_matches_change(branch_name, &rev.change_id) {
+                    if self.github.reopen_pr_if_needed(branch_name)? {
+                        // Add to update list if not already there
+                        if !to_update.iter().any(|r| r.change_id == rev.change_id) {
+                            let mut updated_rev = rev.clone();
+                            updated_rev.branch_name = Some(branch_name.clone());
+                            to_update.push(updated_rev);
                         }
-                        break;
                     }
+                    break;
                 }
             }
         }
@@ -150,31 +153,35 @@ impl AlmightyPush {
         Ok(())
     }
 
+    /// Check whether a managed branch corresponds to the given change id
+    fn branch_matches_change(branch_name: &str, change_id: &str) -> bool {
+        let prefixes = [PUSH_BRANCH_PREFIX, CHANGES_BRANCH_PREFIX];
+
+        for prefix in prefixes {
+            if let Some(stripped) = branch_name.strip_prefix(prefix) {
+                let len = stripped.len().min(change_id.len());
+                return stripped[..len].eq_ignore_ascii_case(&change_id[..len]);
+            }
+        }
+
+        false
+    }
+
     /// Print summary of push operations
-    fn print_push_summary(&self, revisions: &[Revision]) -> Result<()> {
-        if revisions.is_empty() {
+    fn print_push_summary(&self, created_count: usize, updated_count: usize) -> Result<()> {
+        if created_count == 0 && updated_count == 0 {
             return Ok(());
         }
 
-        let (created, updated): (Vec<_>, Vec<_>) = revisions
-            .iter()
-            .partition(|r| r.branch_name.is_some() && !r.has_pr());
-
-        let created_count = created.len();
-        let updated_count = updated.len();
-        let total = created_count + updated_count;
-
-        if total > 0 {
-            if created_count > 0 && updated_count > 0 {
-                eprintln!(
-                    "  Created {} branches, updated {}",
-                    created_count, updated_count
-                );
-            } else if created_count > 0 {
-                eprintln!("  Created {} new branches", created_count);
-            } else {
-                eprintln!("  Updated {} existing branches", updated_count);
-            }
+        if created_count > 0 && updated_count > 0 {
+            eprintln!(
+                "  Created {} branches, updated {}",
+                created_count, updated_count
+            );
+        } else if created_count > 0 {
+            eprintln!("  Created {} new branches", created_count);
+        } else {
+            eprintln!("  Updated {} existing branches", updated_count);
         }
 
         Ok(())

--- a/src/jj.rs
+++ b/src/jj.rs
@@ -7,6 +7,21 @@ use anyhow::Result;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
+const FIELD_SEPARATOR: char = '\u{1f}';
+const REVISION_TEMPLATE: &str = concat!(
+    "change_id.short() ++ \"",
+    "\u{1f}",
+    "\" ++ change_id() ++ \"",
+    "\u{1f}",
+    "\" ++ commit_id.short() ++ \"",
+    "\u{1f}",
+    "\" ++ if(empty, \"EMPTY\", \"NOTEMPTY\") ++ \"",
+    "\u{1f}",
+    "\" ++ parents.map(|p| p.change_id()).join(\",\") ++ \"",
+    "\u{1f}",
+    "\" ++ description.first_line() ++ \"\\n\"",
+);
+
 /// Handles all Jujutsu (jj) operations
 pub struct JujutsuClient {
     executor: CommandExecutor,
@@ -88,21 +103,22 @@ impl JujutsuClient {
 
     /// Get all revisions in the current stack above the base bookmark
     pub fn get_revisions_above_base(&self, base_branch: &str) -> Result<Vec<Revision>> {
+        let revset = format!("{}@{}..@", base_branch, DEFAULT_REMOTE);
         let output = self.executor.run(&[
             "jj",
             "log",
             "-r",
-            &format!("{}@{}..@", base_branch, DEFAULT_REMOTE),
+            &revset,
             "--no-graph",
             "--template",
-            r#"change_id.short() ++ " " ++ commit_id.short() ++ " " ++ if(empty, "EMPTY", "NOTEMPTY") ++ " " ++ description.first_line() ++ "\n""#,
+            REVISION_TEMPLATE,
         ])?;
 
         if output.stdout.trim().is_empty() {
             return Ok(Vec::new());
         }
 
-        let mut revisions = Vec::new();
+        let mut parsed_revisions = Vec::new();
         let mut skipped_empty = Vec::new();
 
         for line in output.stdout.lines() {
@@ -111,26 +127,38 @@ impl JujutsuClient {
                 continue;
             }
 
-            if let Some(revision) = self.parse_revision_line(line) {
-                if revision.description == "EMPTY" {
+            if let Some(parsed) = self.parse_revision_line(line) {
+                if parsed.is_empty {
                     skipped_empty.push(format!(
                         "{} ({})",
-                        revision.short_change_id(),
-                        revision.commit_id
+                        parsed.revision.short_change_id(),
+                        parsed.revision.commit_id
                     ));
                     continue;
                 }
-                revisions.push(revision);
+                parsed_revisions.push(parsed);
             }
         }
 
-        // Reverse to get bottom-up order (oldest first)
-        revisions.reverse();
+        if parsed_revisions.is_empty() {
+            if !skipped_empty.is_empty() {
+                eprintln!(
+                    "  (Skipped empty working copy: {})",
+                    skipped_empty.join(", ")
+                );
+            }
+            return Ok(Vec::new());
+        }
+
+        let mut revisions = self.linearize_stack(parsed_revisions, base_branch)?;
 
         eprintln!("Found {} revisions to push", revisions.len());
 
         if !skipped_empty.is_empty() {
-            eprintln!("  (Skipped empty working copy: {})", skipped_empty[0]);
+            eprintln!(
+                "  (Skipped empty working copy: {})",
+                skipped_empty.join(", ")
+            );
         }
 
         // Validate revisions
@@ -143,29 +171,191 @@ impl JujutsuClient {
     }
 
     /// Parse a single revision line from jj log output
-    fn parse_revision_line(&self, line: &str) -> Option<Revision> {
-        let parts: Vec<&str> = line.splitn(4, ' ').collect();
-        if parts.len() < 3 {
+    fn parse_revision_line(&self, line: &str) -> Option<ParsedRevision> {
+        let parts: Vec<&str> = line.splitn(6, FIELD_SEPARATOR).collect();
+        if parts.len() < 5 {
             return None;
         }
 
         let change_id = parts[0].to_string();
-        let commit_id = parts[1].to_string();
-        let is_empty = parts[2];
-        let description = if parts.len() > 3 {
-            parts[3].trim().to_string()
+        let full_change_id = parts[1].to_string();
+        let commit_id = parts[2].to_string();
+        let is_empty = parts[3] == "EMPTY";
+        let parent_change_ids = if parts[4].trim().is_empty() {
+            Vec::new()
+        } else {
+            parts[4]
+                .split(',')
+                .filter(|parent| !parent.trim().is_empty())
+                .map(|parent| parent.trim().to_string())
+                .collect()
+        };
+
+        let description = if parts.len() > 5 {
+            let desc = parts[5].trim();
+            if desc.is_empty() {
+                "(no description)".to_string()
+            } else {
+                desc.to_string()
+            }
         } else {
             "(no description)".to_string()
         };
 
-        if is_empty == "EMPTY" {
-            // Return a marker revision for empty commits
-            return Some(Revision::new(change_id, commit_id, "EMPTY".to_string()));
-        }
-
-        Some(Revision::new(change_id, commit_id, description))
+        Some(ParsedRevision {
+            revision: Revision::new(
+                change_id,
+                commit_id,
+                if is_empty {
+                    "EMPTY".to_string()
+                } else {
+                    description
+                },
+            ),
+            full_change_id,
+            parent_change_ids,
+            is_empty,
+        })
     }
 
+    fn linearize_stack(
+        &self,
+        parsed_revisions: Vec<ParsedRevision>,
+        base_branch: &str,
+    ) -> Result<Vec<Revision>> {
+        if parsed_revisions.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut id_to_index = HashMap::new();
+        for (index, parsed) in parsed_revisions.iter().enumerate() {
+            id_to_index.insert(parsed.full_change_id.clone(), index);
+        }
+
+        let mut child_map: HashMap<String, String> = HashMap::new();
+        let mut roots = Vec::new();
+
+        for parsed in &parsed_revisions {
+            let mut parents_in_stack = Vec::new();
+            for parent in &parsed.parent_change_ids {
+                if id_to_index.contains_key(parent) {
+                    parents_in_stack.push(parent.clone());
+                }
+            }
+
+            if parents_in_stack.len() > 1 {
+                let parent_labels: Vec<String> = parents_in_stack
+                    .iter()
+                    .filter_map(|parent| id_to_index.get(parent))
+                    .map(|index| {
+                        parsed_revisions[*index]
+                            .revision
+                            .short_change_id()
+                            .to_string()
+                    })
+                    .collect();
+                anyhow::bail!(
+                    "Commit {} merges multiple stack entries ({}). Stacks must be linear.",
+                    parsed.revision.short_change_id(),
+                    parent_labels.join(", ")
+                );
+            }
+
+            if let Some(parent) = parents_in_stack.first() {
+                if let Some(existing_child) =
+                    child_map.insert(parent.clone(), parsed.full_change_id.clone())
+                {
+                    let existing = &parsed_revisions[*id_to_index
+                        .get(&existing_child)
+                        .expect("existing child must exist")];
+                    let parent_rev =
+                        &parsed_revisions[*id_to_index.get(parent).expect("parent must exist")];
+                    anyhow::bail!(
+                        "Stack branches at {} ({} and {} both depend on it). Rebase your stack to be linear before running almighty-push.",
+                        parent_rev.revision.short_change_id(),
+                        existing.revision.short_change_id(),
+                        parsed.revision.short_change_id()
+                    );
+                }
+            } else {
+                roots.push(parsed.full_change_id.clone());
+            }
+        }
+
+        if roots.is_empty() {
+            anyhow::bail!(
+                "Could not determine the base of your stack. Ensure your commits are descendants of {}@{}.",
+                base_branch,
+                DEFAULT_REMOTE
+            );
+        }
+
+        if roots.len() > 1 {
+            let root_labels: Vec<String> = roots
+                .iter()
+                .filter_map(|root| id_to_index.get(root))
+                .map(|index| {
+                    parsed_revisions[*index]
+                        .revision
+                        .short_change_id()
+                        .to_string()
+                })
+                .collect();
+            anyhow::bail!(
+                "Found multiple stack roots ({}). Rebase onto a single {}@{} ancestor before pushing.",
+                root_labels.join(", "),
+                base_branch,
+                DEFAULT_REMOTE
+            );
+        }
+
+        let root_id = roots[0].clone();
+        let mut ordered_ids = Vec::new();
+        let mut current = root_id.clone();
+        let mut visited = HashSet::new();
+
+        loop {
+            if !visited.insert(current.clone()) {
+                let rev =
+                    &parsed_revisions[*id_to_index.get(&current).expect("cycle node must exist")];
+                anyhow::bail!(
+                    "Detected a cycle while traversing the stack at {}. Rebase your stack to be linear.",
+                    rev.revision.short_change_id()
+                );
+            }
+
+            ordered_ids.push(current.clone());
+
+            if let Some(next) = child_map.get(&current) {
+                current = next.clone();
+            } else {
+                break;
+            }
+        }
+
+        if visited.len() != parsed_revisions.len() {
+            let missing: Vec<String> = parsed_revisions
+                .iter()
+                .filter(|parsed| !visited.contains(&parsed.full_change_id))
+                .map(|parsed| parsed.revision.short_change_id().to_string())
+                .collect();
+            anyhow::bail!(
+                "Could not connect all commits into a single stack (unreachable: {}). Rebase your stack to be linear before pushing.",
+                missing.join(", ")
+            );
+        }
+
+        let mut ordered_revisions = Vec::with_capacity(parsed_revisions.len());
+        for id in ordered_ids {
+            let index = id_to_index
+                .get(&id)
+                .copied()
+                .expect("ordered id must exist in map");
+            ordered_revisions.push(parsed_revisions[index].revision.clone());
+        }
+
+        Ok(ordered_revisions)
+    }
     /// Validate that all revisions have descriptions
     fn validate_revisions(&self, revisions: &[Revision]) -> Result<()> {
         let missing_descriptions: Vec<&Revision> = revisions
@@ -478,4 +668,12 @@ impl JujutsuClient {
 
         Ok(())
     }
+}
+
+#[derive(Clone)]
+struct ParsedRevision {
+    revision: Revision,
+    full_change_id: String,
+    parent_change_ids: Vec<String>,
+    is_empty: bool,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,11 +46,6 @@ impl Revision {
         &self.change_id[..self.change_id.len().min(8)]
     }
 
-    /// Check if revision has an associated PR
-    pub fn has_pr(&self) -> bool {
-        self.pr_url.is_some()
-    }
-
     /// Extract PR number from URL
     pub fn extract_pr_number(&self) -> Option<u32> {
         self.pr_url.as_ref().and_then(|url| {


### PR DESCRIPTION
## Summary
- ensure the jj stack is parsed with a rich template and linearized, detecting merges, cycles, and disconnected entries
- tighten almighty-push branch matching and summary reporting by tracking branch names per change-id
- remove the unused Revision::has_pr helper

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d03233ebf48325af05e064ac5156f8